### PR TITLE
Add host metrics to Signoz

### DIFF
--- a/argo/signoz/release.yaml
+++ b/argo/signoz/release.yaml
@@ -39,3 +39,20 @@ spec:
                   - signoz.shrub.dev
                 secretName: signoz-tls
 
+          otelCollector:
+            config:
+              receivers:
+                hostmetrics:
+                  collection_interval: 60s
+                  scrapers:
+                    cpu:
+                    memory:
+                    filesystem:
+                    network:
+              service:
+                pipelines:
+                  metrics:
+                    receivers: [otlp, hostmetrics]
+                    processors: [batch]
+                    exporters: [clickhousemetricswrite, metadataexporter, signozclickhousemetrics]
+


### PR DESCRIPTION
## Summary
- configure Signoz otelCollector with a hostmetrics receiver
- update metrics pipeline to include host metrics

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857d4bc40348332921ce174d29f773e