### PR TITLE
Constrain SigNoz ClickHouse scheduling to preferred nodes

### DIFF
--- a/argo/signoz/release.yaml
+++ b/argo/signoz/release.yaml
@@ -56,3 +56,15 @@ spec:
                     processors: [batch]
                     exporters: [clickhousemetricswrite, metadataexporter, signozclickhousemetrics]
 
+        clickhouse:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - stanley
+                          - phyllis
+


### PR DESCRIPTION
## Summary
- add node affinity so SigNoz ClickHouse pods schedule on either the stanley or phyllis nodes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfb85433148332ae1f6c7afb6d0a13